### PR TITLE
Added support for separating classAccesses elements 

### DIFF
--- a/messages/decompose.json
+++ b/messages/decompose.json
@@ -3,6 +3,7 @@
     "sourcePathFlagDescription" : "The path to the directory containing the original profile XML files.  Default value is './force-app/main/default/profiles'.",
     "decomposeDirFlagDescription" : "The name of the directory where decomposed metadata files reside.",
     "noProdFlagDescription": "If present/true, production-only profile permissions will be stripped from the decomposed profile files.",
+    "separateClassAccessDescription" : "If present/true, separates the classAccesses elements into a separate file for each profile",
     "errorFileSave" : "Error writing saving file %s",
     "errorSourcePathNotFound" : "Source path not found.",
     "errorDecomposeDirNotFound" : "Decompose directory not found.",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "pretty-quick": "^3.1.2",
     "sinon": "^12.0.1",
     "ts-node": "^10.4.0",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "xml-query": "^1.5.0",
+    "xml-reader": "^2.4.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/src/commands/profiles/aggregate.ts
+++ b/src/commands/profiles/aggregate.ts
@@ -15,70 +15,70 @@ Messages.importMessagesDirectory(__dirname, true, 'sfdx-profile-decompose');
 const messages = Messages.loadMessages('sfdx-profile-decompose', 'aggregate');
 
 /**
- * CLI command which re-bundles decomposed metadata files back
- * into their original (monolithic) format.  Expects the decomposed files
- * to be in the format output by the `profiles:decompose` command.
- */
+* CLI command which re-bundles decomposed metadata files back
+* into their original (monolithic) format.  Expects the decomposed files
+* to be in the format output by the `profiles:decompose` command.
+*/
 export default class Aggregate extends SfdxCommand {
-
+    
     public static description: string = messages.getMessage('commandDescription');
     public static examples = [
         '$ sfdx profiles:aggregate --source-path=path/to/source --decompose-dir=decomposed'
     ];
-
+    
     public static args = [];
     protected static flagsConfig = {
         'source-path': flags.directory({ char: 's', description: messages.getMessage('sourcePathFlagDescription'), default: Utils.DEFAULT_SOURCE_PATH }),
         'decompose-dir': flags.string({ char: 'd', description: messages.getMessage('decomposeDirFlagDescription'), default: Utils.DEFAULT_DECOMPOSE_DIR }),
         'md-types': flags.array({char: 'm', description: messages.getMessage('metadataTypesFlagDescription'), default: ['profiles', 'permissionsets']})
     };
-
+    
     // Comment this out if your command does not require an org username
     protected static requiresUsername = false;
-
+    
     // Comment this out if your command does not support a hub org username
     protected static supportsDevhubUsername = false;
-
+    
     // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
     protected static requiresProject = false;
-
+    
     /**
-     * Execute the command.
-     */
+    * Execute the command.
+    */
     public async run(): Promise<AnyJson> {
         const sourcePath = this.flags['source-path'] || Utils.DEFAULT_SOURCE_PATH;
         if (!fs.existsSync(sourcePath)) {
             throw new SfdxError(messages.getMessage('errorSourcePathNotFound', [sourcePath]));
         }
         const decomposeDir = this.flags['decompose-dir'] || Utils.DEFAULT_DECOMPOSE_DIR;
-
+        
         const mdTypes = this.flags['md-types'];
         const processedComponents = {};
-		await Promise.all(mdTypes.map(async mdType => {
-			const mdSourcePath = path.join(sourcePath, mdType);
-			const mdDecomposedPath = path.join(mdSourcePath, decomposeDir);
-			if (!fs.existsSync(mdDecomposedPath)) {
-				throw new SfdxError(messages.getMessage('errorDecomposeDirNotFound', [mdDecomposedPath]));
-			}
-			const componentConfig = Utils.MD_TYPE_CONFIGS[mdType];
-			const suffix = componentConfig['mdSuffix'];
-
-			let names: string[] = [];
-			const mdDirs: fs.Dirent[] = await fs.promises.readdir(mdDecomposedPath, { withFileTypes: true });
-			if (mdDirs && mdDirs.length) {
-				names = await Promise.all(mdDirs.filter(f => !f.name.startsWith('.') && f.isDirectory()).map(async dirent => {
-					const componentName: string = dirent.name;
-					const mdComponent = await this.aggregateComponent(componentName, path.join(mdDecomposedPath, dirent.name), componentConfig['objectName']);
-					await this.saveAggregatedComponent(mdComponent, componentConfig['objectName'], `${path.join(mdSourcePath, componentName)}${suffix}`);
-					return componentName;
-				}));
-			}
-			processedComponents[mdType] = names;
-		}));
+        await Promise.all(mdTypes.map(async mdType => {
+            const mdSourcePath = path.join(sourcePath, mdType);
+            const mdDecomposedPath = path.join(mdSourcePath, decomposeDir);
+            if (!fs.existsSync(mdDecomposedPath)) {
+                throw new SfdxError(messages.getMessage('errorDecomposeDirNotFound', [mdDecomposedPath]));
+            }
+            const componentConfig = Utils.MD_TYPE_CONFIGS[mdType];
+            const suffix = componentConfig['mdSuffix'];
+            
+            let names: string[] = [];
+            const mdDirs: fs.Dirent[] = await fs.promises.readdir(mdDecomposedPath, { withFileTypes: true });
+            if (mdDirs && mdDirs.length) {
+                names = await Promise.all(mdDirs.filter(f => !f.name.startsWith('.') && f.isDirectory()).map(async dirent => {
+                    const componentName: string = dirent.name;
+                    const mdComponent = await this.aggregateComponent(componentName, path.join(mdDecomposedPath, dirent.name), componentConfig['objectName']);
+                    await this.saveAggregatedComponent(mdComponent, componentConfig['objectName'], `${path.join(mdSourcePath, componentName)}${suffix}`);
+                    return componentName;
+                }));
+            }
+            processedComponents[mdType] = names;
+        }));
         
         return processedComponents;
     }
-
+    
     private async saveAggregatedComponent(mdComponent: object, componentType: string, filename: string) {
         // need to prepend the XML tag and add the xmlns attribute to the root object
         const xmlPrepender = (input: string) => {
@@ -92,42 +92,42 @@ export default class Aggregate extends SfdxCommand {
             throw new SfdxError(messages.getMessage('errorFileSave', [filename]));
         }
     }
-
+    
     /**
-     * Reads all decomposed metadata XML files and reconstructs the original metadata from them.
-     * @param componentName the name of the metadata component
-     * @param componentPath the path to the root of the component's XML files.
-     */
+    * Reads all decomposed metadata XML files and reconstructs the original metadata from them.
+    * @param componentName the name of the metadata component
+    * @param componentPath the path to the root of the component's XML files.
+    */
     private async aggregateComponent(componentName: string, componentPath: string, componentType: string): Promise<object> {
         const coreMdFile = `${componentPath}/${componentName}.xml`;
-		const parsedMd = await this.readAndParseMetadata(coreMdFile);
+        const parsedMd = await this.readAndParseMetadata(coreMdFile);
         const classAccessesFile = `${componentPath}/classAccesses.xml`;
         if (fs.existsSync(classAccessesFile)) {
             const classAccesses = await this.readAndParseMetadata(classAccessesFile);
             parsedMd[componentType]['classAccesses'] = classAccesses[componentType]['classAccesses'].reduce((acc: object[], val) => acc.concat(val), []);
         }
-		await Promise.all(Object.keys(Utils.OBJECT_PROPS).map(async propertyType => {
-			// loop over each property type (e.g., 'fieldPermissions') and aggregate the properties from each
-			// object's XML file into a single array of properties
-			const permTypePath = path.join(componentPath, propertyType);
-			if (fs.existsSync(permTypePath)) {
-				const objectPermFiles: fs.Dirent[] = await fs.promises.readdir(permTypePath, { withFileTypes: true });
-				const objectPerms: object[] = await Promise.all(objectPermFiles.filter(f => f.isFile() && f.name.toLowerCase().endsWith('.xml'))
-					.map(async permFile => {
-						const perms = await this.readAndParseMetadata(path.join(permTypePath, permFile.name));
-						return perms[componentType][propertyType];
-					}));
-				parsedMd[componentType][propertyType] = objectPerms.reduce((acc: object[], val) => acc.concat(val), []);
-			}
-		}));
-		return parsedMd;
-
-	}
-
+        await Promise.all(Object.keys(Utils.OBJECT_PROPS).map(async propertyType => {
+            // loop over each property type (e.g., 'fieldPermissions') and aggregate the properties from each
+            // object's XML file into a single array of properties
+            const permTypePath = path.join(componentPath, propertyType);
+            if (fs.existsSync(permTypePath)) {
+                const objectPermFiles: fs.Dirent[] = await fs.promises.readdir(permTypePath, { withFileTypes: true });
+                const objectPerms: object[] = await Promise.all(objectPermFiles.filter(f => f.isFile() && f.name.toLowerCase().endsWith('.xml'))
+                .map(async permFile => {
+                    const perms = await this.readAndParseMetadata(path.join(permTypePath, permFile.name));
+                    return perms[componentType][propertyType];
+                }));
+                parsedMd[componentType][propertyType] = objectPerms.reduce((acc: object[], val) => acc.concat(val), []);
+            }
+        }));
+        return parsedMd;
+        
+    }
+    
     /**
-     * Reads component metadata from a file and parses it into an object.
-     * @param mdPath the location of the XML file to be read
-     */
+    * Reads component metadata from a file and parses it into an object.
+    * @param mdPath the location of the XML file to be read
+    */
     private async readAndParseMetadata(mdPath: string): Promise<object> {
         let mdComponent: object = null;
         try {
@@ -140,7 +140,7 @@ export default class Aggregate extends SfdxCommand {
             // exception will be thrown below
         }
         if (!mdComponent) {
-			throw new SfdxError(messages.getMessage('errorXmlParse', [`Parsing ${mdPath} failed.`]));
+            throw new SfdxError(messages.getMessage('errorXmlParse', [`Parsing ${mdPath} failed.`]));
         }
         return mdComponent;
     }

--- a/test/commands/profiles/aggregate.test.ts
+++ b/test/commands/profiles/aggregate.test.ts
@@ -6,7 +6,6 @@ import testUtils from '../../utils';
 const sourcePath = path.join('test','data', 'aggregate');
 const decomposeDir = 'decomposed';
 
-const decomposeCmdArgs = ['profiles:decompose', '--source-path', sourcePath, '--decompose-dir', decomposeDir, '--no-prod', '--md-types', 'profiles'];
 const aggregateCommandArgs = ['profiles:aggregate', '--source-path', sourcePath, '--decompose-dir', decomposeDir, '--md-types', 'profiles'];
 
 const aggregatedFile = path.join(sourcePath, 'profiles', 'Admin.profile-meta.xml');
@@ -53,14 +52,13 @@ describe('profiles:aggregate', () => {
     });
 
     test
-    .command(decomposeCmdArgs)
     .command(aggregateCommandArgs)
     .it('handles multiple profiles', ctx => {
         expect(fs.existsSync(path.join(sourcePath, 'profiles', 'Other.profile-meta.xml'))).to.be.true;
+        expect(fs.existsSync(path.join(sourcePath, 'profiles', 'Admin.profile-meta.xml'))).to.be.true;
     });
 
     test
-    .command(decomposeCmdArgs)
     .command(aggregateCommandArgs)
     .it('handles empty permnission sections', ctx => {
         const xq = testUtils.xmlQueryFromFile(path.join(sourcePath, 'profiles', 'Other.profile-meta.xml'));
@@ -68,7 +66,6 @@ describe('profiles:aggregate', () => {
     });
 
     test
-    .command(decomposeCmdArgs)
     .command(aggregateCommandArgs)
     .it('includes core permissions', ctx => {
         const xq = testUtils.xmlQueryFromFile(aggregatedFile);
@@ -78,7 +75,6 @@ describe('profiles:aggregate', () => {
     });
 
     test
-    .command(decomposeCmdArgs)
     .command(aggregateCommandArgs)
     .it('includes all object permissions', ctx => {
         const xq = testUtils.xmlQueryFromFile(aggregatedFile);

--- a/test/commands/profiles/aggregate.test.ts
+++ b/test/commands/profiles/aggregate.test.ts
@@ -40,10 +40,16 @@ describe('profiles:aggregate', () => {
     });
 
     test
-    .command(decomposeCmdArgs)
     .command(aggregateCommandArgs)
     .it('creates aggregated profile XML', ctx => {
         expect(fs.existsSync(aggregatedFile)).to.be.true;
+    });
+
+    test
+    .command(['profiles:aggregate', '--source-path', sourcePath, '--decompose-dir', decomposeDir, '--md-types', 'profiles'])
+    .it('aggregates classAccesses from a separate file', ctx => {
+        const xq = testUtils.xmlQueryFromFile(path.join(sourcePath, 'profiles', 'Admin.profile-meta.xml'));
+        expect(xq.find('classAccesses')).to.have.length(2);
     });
 
     test

--- a/test/commands/profiles/decompose.test.ts
+++ b/test/commands/profiles/decompose.test.ts
@@ -215,4 +215,26 @@ describe("profiles:decompose", () => {
         const xq = testUtils.xmlQueryFromFile(path.join(sourceDir, 'permissionsets', 'decomposed', 'Services_Delivery_App_User', 'Services_Delivery_App_User.xml'));
         expect(xq.find('applicationVisibilities')).to.have.length(1);
     });
+
+    test
+    .command([
+        'profiles:decompose',
+        '--source-path',  sourceDir,
+        '--decompose-dir', 'decomposed',
+        '--no-prod',
+        '--md-types', 'profiles',
+        '--separate-classes'])
+    .it('separates classAccesses', ctx => {
+        const adminProfilePath = path.join(sourceDir, 'profiles', 'decomposed', 'Admin', 'Admin.xml');
+        expect(fs.existsSync(adminProfilePath)).to.be.true;
+        let xq =  testUtils.xmlQueryFromFile(adminProfilePath);
+        expect(xq.has('classAccesses')).to.be.false;
+
+        const classAccessesPath = path.join(sourceDir, 'profiles', 'decomposed', 'Admin', 'classAccesses.xml');
+        expect(fs.existsSync(classAccessesPath)).to.be.true;
+
+        xq = testUtils.xmlQueryFromFile(classAccessesPath);
+        const classAccesses = xq.find('classAccesses');
+        expect(classAccesses).to.have.length(2);
+    });
 });

--- a/test/data/aggregate/profiles/decomposed/Admin/Admin.xml
+++ b/test/data/aggregate/profiles/decomposed/Admin/Admin.xml
@@ -27,14 +27,4 @@
         <enabled>true</enabled>
         <name>ActivateOrder</name>
     </userPermissions>
-    <classAccesses>
-        <classAccesses>
-            <apexClass>AccountBusinessLineUpdateHandler</apexClass>
-            <enabled>false</enabled>
-        </classAccesses>
-        <classAccesses>
-            <apexClass>AccountBusinessLineUpdateHandlerTest</apexClass>
-            <enabled>false</enabled>
-        </classAccesses>
-    </classAccesses>
 </Profile>

--- a/test/data/aggregate/profiles/decomposed/Admin/Admin.xml
+++ b/test/data/aggregate/profiles/decomposed/Admin/Admin.xml
@@ -9,14 +9,6 @@
         <default>false</default>
         <visible>true</visible>
     </applicationVisibilities>
-    <classAccesses>
-        <apexClass>AccountBusinessLineUpdateHandler</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>AccountBusinessLineUpdateHandlerTest</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
     <custom>false</custom>
     <pageAccesses>
         <apexPage>AccountDetailPage</apexPage>
@@ -35,4 +27,14 @@
         <enabled>true</enabled>
         <name>ActivateOrder</name>
     </userPermissions>
+    <classAccesses>
+        <classAccesses>
+            <apexClass>AccountBusinessLineUpdateHandler</apexClass>
+            <enabled>false</enabled>
+        </classAccesses>
+        <classAccesses>
+            <apexClass>AccountBusinessLineUpdateHandlerTest</apexClass>
+            <enabled>false</enabled>
+        </classAccesses>
+    </classAccesses>
 </Profile>

--- a/test/data/aggregate/profiles/decomposed/Admin/classAccesses.xml
+++ b/test/data/aggregate/profiles/decomposed/Admin/classAccesses.xml
@@ -1,0 +1,10 @@
+<Profile>
+    <classAccesses>
+        <apexClass>AccountBusinessLineUpdateHandler</apexClass>
+        <enabled>false</enabled>
+    </classAccesses>
+    <classAccesses>
+        <apexClass>AccountBusinessLineUpdateHandlerTest</apexClass>
+        <enabled>false</enabled>
+    </classAccesses>
+</Profile>


### PR DESCRIPTION
Adds support for a new command-line arg (`separate-classes` or `c`) to the decompose command that separates `<classAccesses>` elements into a separate file.

When using the aggregate command, no additional arg is needed.  If 'classAccesses.xml' files are found in the root of a profile or permission set directory, they will be built into the monolithic XML file output.